### PR TITLE
Add JUSO Coworking link and improve contact form name input

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -754,11 +754,12 @@
 
         <script>
           document.getElementById('sendButton').addEventListener('click', function () {
-            const name = document.getElementById('contact-name').value.trim();
+            const inputName = document.getElementById('contact-name').value.trim();
+            const name = inputName === '' ? '名無し' : inputName;
             const email = document.getElementById('email').value.trim();
             const message = document.getElementById('message').value.trim();
 
-            const subject = encodeURIComponent(`${name}からの問い合わせ`);
+            const subject = encodeURIComponent(`${name}さんからの問い合わせ`);
             const body = encodeURIComponent(`メール: ${email}\n\n内容:\n${message}`);
 
             const mailtoLink = `mailto:info@hogehoge.co.jp?subject=${subject}&body=${body}`;

--- a/public/index.html
+++ b/public/index.html
@@ -642,7 +642,7 @@
           <tr><td>所在地</td><td>
             532-0023<br>
             大阪市淀川区十三東1丁目17-13 水交ビル403号<br>
-            (JUSO Coworking内)
+            (<a href="https://juso-coworking.com/" target="_blank" title="JUSO Coworking">JUSO Coworking</a>内)
           </td></tr>
           <tr><td>役員</td><td>
             代表取締役 Chief Executive Officer 佐敷亮太<br>


### PR DESCRIPTION
Enhance the contact information by adding a link to JUSO Coworking and improving the name input in the contact form to set a default name when left empty.